### PR TITLE
Updating preload tables for external username

### DIFF
--- a/assets/preloadTables.psql
+++ b/assets/preloadTables.psql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS social_logins
   user_data_uri text NOT NULL,
   external_user_id_json_field_path text NOT NULL,
   external_user_email_json_field_path text NOT NULL,
+  external_username_json_field_path text NOT NULL,
   token_type_json_field_path text NOT NULL,
   requested_with_auth_header boolean NOT NULL
 );
@@ -34,5 +35,6 @@ CREATE TABLE IF NOT EXISTS social_login_mappings
 (
   social_login_key text NOT NULL,
   username text NOT NULL, 
-  external_user_id text NOT NULL
+  external_user_id text NOT NULL,
+  external_username text
 );


### PR DESCRIPTION
Updated preload table queries and made external_username column on social login mapping table as nullable, because some social apps do not have username property, for example Facebook.